### PR TITLE
Increase the wait time for starting up the Splunk server

### DIFF
--- a/src/test/java/SplunkDockerImageTest.java
+++ b/src/test/java/SplunkDockerImageTest.java
@@ -47,8 +47,8 @@ public class SplunkDockerImageTest {
             // Create and run container
             dockerUtility.createAndRunContainer(dockerImage, containerName, true);
 
-            // Wait 20s for the Splunk server to start up
-            Thread.sleep(20_000);
+            // Wait 30s for the Splunk server to start up
+            Thread.sleep(30_000);
 
             // Test if the connection to the database is successful
             Assertions.assertDoesNotThrow(() -> connectToSplunk(dockerImage));


### PR DESCRIPTION
Closes #16.
Fix 'remote host terminated handshake' error in SplunkDockerImageTest by increasing wait time to 30 seconds.