### PR TITLE
Update README.md with the latest list of supported docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This library lets you deploy and manage docker images/containers via Java.
   - MS-SQL 2017
   - MS-SQL 2019
   - MySQL
+  - MongoDB
+  - Splunk
 
 # Usage
 Here's an example code to deploy/terminate a MS-SQL docker container via Adya:


### PR DESCRIPTION
Closes #18.
The previous README.md was outdated.
Updated it to reflect all docker images that are supported currently.